### PR TITLE
Forwardport "feat(defines): More defines to extend testing capabilities"

### DIFF
--- a/coapthon/defines.py
+++ b/coapthon/defines.py
@@ -208,6 +208,7 @@ class Codes(object):
     CONTINUE = CodeItem(95, 'CONTINUE')
 
     BAD_REQUEST = CodeItem(128, 'BAD_REQUEST')
+    UNAUTHORIZED = CodeItem(129, 'UNAUTHORIZED')
     FORBIDDEN = CodeItem(131, 'FORBIDDEN')
     NOT_FOUND = CodeItem(132, 'NOT_FOUND')
     METHOD_NOT_ALLOWED = CodeItem(133, 'METHOD_NOT_ALLOWED')
@@ -239,6 +240,7 @@ class Codes(object):
         95: CONTINUE,
 
         128: BAD_REQUEST,
+        129: UNAUTHORIZED,
         131: FORBIDDEN,
         132: NOT_FOUND,
         133: METHOD_NOT_ALLOWED,

--- a/coapthon/defines.py
+++ b/coapthon/defines.py
@@ -128,6 +128,7 @@ class OptionRegistry(object):
     PROXY_SCHEME =  OptionItem(39, "Proxy-Schema",  STRING,  False, None)
     SIZE1 =         OptionItem(60, "Size1",         INTEGER, False, None)
     NO_RESPONSE =   OptionItem(258, "No-Response",  INTEGER, False, None)
+    VENDOR_SPECIFIC_OPTION_2048 = OptionItem(2048, "Vendor-specific-option-2048",  OPAQUE, False, None)
     RM_MESSAGE_SWITCHING = OptionItem(65524, "Routing", OPAQUE, False, None)
 
     LIST = {
@@ -151,6 +152,7 @@ class OptionRegistry(object):
         39: PROXY_SCHEME,
         60: SIZE1,
         258: NO_RESPONSE,
+        2048: VENDOR_SPECIFIC_OPTION_2048,
         65524: RM_MESSAGE_SWITCHING
 
     }


### PR DESCRIPTION
Exactly changes from https://github.com/tadodotcom/CoAPthon/pull/5

These changes are necessary for _device_config_invalidate_etag.py_ system test.