### PR TITLE
fix(message): Allow etags to be of type None

### DIFF
--- a/coapthon/messages/message.py
+++ b/coapthon/messages/message.py
@@ -454,7 +454,8 @@ class Message(object):
         for e in etag:
             option = Option()
             option.number = defines.OptionRegistry.ETAG.number
-            if not  isinstance(e, bytes):
+            if isinstance(e, str):
+                # if etag was accidentally set to str, convert it to bytes
                 e = bytes(e, "utf-8")
             option.value = e
             self.add_option(option)


### PR DESCRIPTION
Another example of why one shouldn't blindly convert everything to `bytes` just by assuming that the input is always `str`.

In [original Coapthon2](https://github.com/tadodotcom/CoAPthon/blob/de257518fe03548d981af06c7b6a00c06822213a/coapthon/messages/message.py#L454-L458) this line looks like:

```python
        for e in etag:
            option = Option()
            option.number = defines.OptionRegistry.ETAG.number
            option.value = e
            self.add_option(option)
```

It simply copies new tag into option.value. In python3 this would be wrong for strings, because options are expected to be `bytes`, not encoded strings. Blind conversion of incoming tag into `bytes` is wrong because it is allowed for it to be `None`, what happens during our _device_config_invalidate_etag.py_ test case.