### PR TITLE
fix(deserializer): Correct bytes slices convertion to ints

### DIFF
--- a/coapthon/serializer.py
+++ b/coapthon/serializer.py
@@ -302,11 +302,10 @@ class Serializer(object):
         if h_nibble <= 12:
             value = h_nibble
         elif h_nibble == 13:
-            value = struct.unpack("!B", values[pos].to_bytes(1, "big"))[0] + 13
+            value = struct.unpack("!B", values[pos:pos+1])[0] + 13
             pos += 1
         elif h_nibble == 14:
-            s = struct.Struct("!H")
-            value = s.unpack_from(values[pos:].to_bytes(2, "big"))[0] + 269
+            value = struct.unpack("!H", values[pos:pos+2])[0] + 269
             pos += 2
         else:
             raise AttributeError("Unsupported option number nibble " + str(h_nibble))
@@ -314,10 +313,10 @@ class Serializer(object):
         if l_nibble <= 12:
             length = l_nibble
         elif l_nibble == 13:
-            length = struct.unpack("!B", values[pos].to_bytes(1, "big"))[0] + 13
+            length = struct.unpack("!B", values[pos:pos+1])[0] + 13
             pos += 1
         elif l_nibble == 14:
-            length = s.unpack_from(values[pos:].to_bytes(2, "big"))[0] + 269
+            length = struct.unpack("!H", values[pos:pos+2])[0] + 269
             pos += 2
         else:
             raise AttributeError("Unsupported option length nibble " + str(l_nibble))


### PR DESCRIPTION
In python3 `bytes` slicing has an interesting/annoying edge case. If `b` is `bytes`, then `b[0:2]` will be of type `bytes` with length 2 (expected), `b[0:1]` will be of type `bytes` with length 1 (expected again), but `b[0]` is suddenly of type `int` and `len()` operation becomes unapplicable.

Deserializer code is clearly not expecting that and clearly was never tested. We unfortunately use option `2048` for tado-specific RF-keys (if i recall it correctly), so we hit this issue pretty early in _device_config_invalidate_etag.py_ system test.

There is definitely another issue with the code that variable `s` defined at line 308 of old code could be not available at line 320 of old code. It was also resolved with my change.