### PR TITLE
test(coapthon): Use old name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(
-    name='CoAPthon3',
+    name='coapthon',
     version='1.0.1',
     packages=['coapthon', 'coapthon.caching', 'coapthon.layers', 'coapthon.client', 'coapthon.server', 'coapthon.messages',
               'coapthon.forward_proxy', 'coapthon.resources', 'coapthon.reverse_proxy'],


### PR DESCRIPTION
A hacky way to resolve incompatibilities with pip 20.3 (tadodotcom/SmartThermostat#17784):

```
 ['~/.local/share/virtualenvs/venv3-tMtqgX2O/bin/pip', 'install', '--src', '~/.local/share/virtualenvs/venv3-tMtqgX2O/src', '--verbose', '--upgrade', '"git+git://github.com/tadodotcom/CoAPthon3@05a30e9b26b54d5d097f14ff1fb271c52e52cf23#egg=coapthon"', '-i', 'https://pypi.org/simple']                                                                                                                      
Using pip 20.3 from /home/denis/.local/share/virtualenvs/venv3-tMtqgX2O/lib/python3.6/site-packages/pip (python 3.6)                                                                                               
Non-user install by explicit request                                                                                                                                                                               
Created temporary directory: /tmp/pip-ephem-wheel-cache-clvwgk_q                                                                                                                                                   
Created temporary directory: /tmp/pip-req-tracker-rt10qx9w                                                                                                                                                         
Initialized build tracking at /tmp/pip-req-tracker-rt10qx9w                                                                                                                                                        
Created build tracker: /tmp/pip-req-tracker-rt10qx9w                                                                                                                                                               
Entered build tracker: /tmp/pip-req-tracker-rt10qx9w                                                                                                                                                               
Created temporary directory: /tmp/pip-install-ihgn6_yt                                                                                                                                                             
Collecting coapthon                                                                                                                                                                                                
  Cloning git://github.com/tadodotcom/CoAPthon3 (to revision 05a30e9b26b54d5d097f14ff1fb271c52e52cf23) to /tmp/pip-install-ihgn6_yt/coapthon_21bcc645da1d469a8c16d5d8e85516db                                      
  Added coapthon from git+git://github.com/tadodotcom/CoAPthon3@05a30e9b26b54d5d097f14ff1fb271c52e52cf23#egg=coapthon to build tracker '/tmp/pip-req-tracker-rt10qx9w'                                             
    Running setup.py (path:/tmp/pip-install-ihgn6_yt/coapthon_21bcc645da1d469a8c16d5d8e85516db/setup.py) egg_info for package coapthon                                                                             
    Created temporary directory: /tmp/pip-pip-egg-info-456bs812                                                                                                                                                    
  Source in /tmp/pip-install-ihgn6_yt/coapthon_21bcc645da1d469a8c16d5d8e85516db has version 1.0.1, which satisfies requirement coapthon3 from git+git://github.com/tadodotcom/CoAPthon3@05a30e9b26b54d5d097f14ff1fb
271c52e52cf23#egg=coapthon                                                                                                                                                                                         
  Removed coapthon3 from git+git://github.com/tadodotcom/CoAPthon3@05a30e9b26b54d5d097f14ff1fb271c52e52cf23#egg=coapthon from build tracker '/tmp/pip-req-tracker-rt10qx9w'                                        
Exception information:                                                                                                                                                                                             
Traceback (most recent call last):                                                                                                                                                                                 
  File "/home/denis/.local/share/virtualenvs/venv3-tMtqgX2O/lib/python3.6/site-packages/pip/_vendor/resolvelib/resolvers.py", line 171, in _merge_into_criterion                                                   
    crit = self.state.criteria[name]                                                                                                                                                                               
KeyError: 'coapthon'

pip._internal.exceptions.MetadataInconsistent: Requested coapthon3 from git+git://github.com/tadodotcom/CoAPthon3@05a30e9b26b54d5d097f14ff1fb271c52e52cf23#egg=coapthon has different name in metadata: 'CoAPthon3'
Removed build tracker: '/tmp/pip-req-tracker-rt10qx9w'
```